### PR TITLE
Improve classname helper typing

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -2,3 +2,4 @@
 pnpm-lock.yaml
 package-lock.json
 yarn.lock
+src/styles/palette.css

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
 		"svelte-check": "^4.2.1",
 		"tslib": "^2.8.1",
 		"typescript": "^5.8.3",
+		"typescript-eslint": "^8.32.1",
 		"vite": "^6.3.5",
 		"wrangler": "^4.15.2"
 	}

--- a/src/components/Extract.svelte
+++ b/src/components/Extract.svelte
@@ -18,6 +18,7 @@
 		element?: T;
 		suppressBlockLink?: boolean;
 		variant?: 'default' | 'card';
+		class?: string;
 	}
 
 	let {

--- a/src/helpers/classnames.ts
+++ b/src/helpers/classnames.ts
@@ -1,3 +1,3 @@
-export const classnames = (...args: any[]): string => {
+export const classnames = (...args: (string | false | null | undefined)[]): string => {
 	return args.filter(Boolean).join(' ');
 };

--- a/src/helpers/params.ts
+++ b/src/helpers/params.ts
@@ -1,4 +1,5 @@
 export type EntityTypeKey = 'creator' | 'space' | 'extract';
+
 export interface EntityType {
 	key: EntityTypeKey;
 	urlParam: string;

--- a/src/routes/[entityType]/[...id]/+page.server.ts
+++ b/src/routes/[entityType]/[...id]/+page.server.ts
@@ -18,7 +18,7 @@ export async function load({ params, fetch }) {
 	}
 
 	if (!recordIdRegex.test(id)) {
-		let idSegments = id.split('/');
+		const idSegments = id.split('/');
 		let searchTable;
 		if (idSegments.length > 1) {
 			const extractId = idSegments[1];

--- a/src/routes/app/ExtractSEO.svelte
+++ b/src/routes/app/ExtractSEO.svelte
@@ -32,7 +32,7 @@
 	<meta property="og:site_name" content="barnsworthburning" />
 	<meta property="og:url" content={`https://barnsworthburning.net/extracts/${extract.id}`} />
 	<meta property="og:type" content="article" />
-	{#each extract.creators || extract.parentCreators || [] as creator}
+	{#each extract.creators || extract.parentCreators || [] as creator (creator.id)}
 		<meta name="author" content={creator.name} />
 		<meta property="og:article:author" content={creator.name} />
 	{/each}
@@ -41,7 +41,7 @@
 		content={new Date(extract.extractedOn).toISOString()}
 	/>
 	<meta property="og:article:modified_time" content={modified} />
-	{#each extract.images || [] as image}
+	{#each extract.images || [] as image (image.id)}
 		<meta property="og:image" content={image.url} />
 	{/each}
 </svelte:head>

--- a/src/routes/feed.xml/+server.ts
+++ b/src/routes/feed.xml/+server.ts
@@ -33,7 +33,7 @@ const generateContentMarkup = (extract: IExtract, isChild: boolean = false) => {
 		spaces,
 		parent
 	} = extract;
-	let type = (format || 'extract').toLowerCase();
+	const type = (format || 'extract').toLowerCase();
 	let markup = '<article>\n';
 	if (!isChild) {
 		markup += '<header>\n';
@@ -74,7 +74,7 @@ const generateContentMarkup = (extract: IExtract, isChild: boolean = false) => {
 		let linkText;
 		try {
 			linkText = new URL(source).hostname;
-		} catch (error) {
+		} catch {
 			linkText = source;
 		}
 		markup += `<p>Source: <a href="${source}">${linkText}</a></p>\n`;

--- a/src/routes/tests/+page.svelte
+++ b/src/routes/tests/+page.svelte
@@ -20,11 +20,11 @@
 </script>
 
 <main>
-	{#each testSections as testClass}
+	{#each testSections as testClass (testClass)}
 		<section class={testClass}>
 			<h2>{testClass}</h2>
 			<div>
-				{#each themes as { mode, palette, chroma }}
+				{#each themes as { mode, palette, chroma } (`${mode || ''} ${palette || ''} ${chroma || ''}`)}
 					<TestCard {mode} {palette} {chroma} />
 				{/each}
 			</div>

--- a/src/styles/generators.ts
+++ b/src/styles/generators.ts
@@ -18,7 +18,7 @@ const alphaSuffix = 'A';
 const numSteps = 12;
 const rampLevels = Array.from({ length: numSteps }, (_, i) => i + 1);
 
-const generateShadeRamp = (shade: Shade, isP3: Boolean) => {
+const generateShadeRamp = (shade: Shade, isP3: boolean) => {
 	const p3 = isP3 ? p3Suffix : '';
 	const alphaRamp: Ramp = radix[`${shade}${p3}${alphaSuffix}`];
 
@@ -30,7 +30,7 @@ const generateShadeRamp = (shade: Shade, isP3: Boolean) => {
 	return css;
 };
 
-const generateShadeClasses = (isP3: Boolean = false) => {
+const generateShadeClasses = (isP3: boolean = false) => {
 	let css = ':root {\n';
 	css += generateShadeRamp(Shade.Black, isP3);
 	css += '\n';
@@ -39,7 +39,7 @@ const generateShadeClasses = (isP3: Boolean = false) => {
 	return css;
 };
 
-const generateVariableRamp = (palette: Palette, isP3: Boolean, isNeutral: Boolean) => {
+const generateVariableRamp = (palette: Palette, isP3: boolean, isNeutral: boolean) => {
 	const p3 = isP3 ? p3Suffix : '';
 	const type = isNeutral ? 'neu' : 'clr';
 	const lightRamp: Ramp = radix[`${palette}${p3}`];
@@ -71,7 +71,7 @@ const generateVariableRamp = (palette: Palette, isP3: Boolean, isNeutral: Boolea
 
 const NO_CLASS = ':root:where(:not([class]), [class=""])';
 
-const generateColorClasses = (isP3: Boolean = false) => {
+const generateColorClasses = (isP3: boolean = false) => {
 	let css = '';
 	for (const palette of paletteOptions) {
 		const selectors = [`.${palette}`];
@@ -86,7 +86,7 @@ const generateColorClasses = (isP3: Boolean = false) => {
 	return css;
 };
 
-const generateNeutralClasses = (isP3: Boolean = false) => {
+const generateNeutralClasses = (isP3: boolean = false) => {
 	let css = '';
 	for (const neutral in neutralsMap) {
 		const palettes = neutralsMap[neutral as Neutral];

--- a/yarn.lock
+++ b/yarn.lock
@@ -1184,7 +1184,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/eslint-plugin@npm:^8.32.1":
+"@typescript-eslint/eslint-plugin@npm:8.32.1, @typescript-eslint/eslint-plugin@npm:^8.32.1":
   version: 8.32.1
   resolution: "@typescript-eslint/eslint-plugin@npm:8.32.1"
   dependencies:
@@ -1205,7 +1205,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/parser@npm:^8.32.1":
+"@typescript-eslint/parser@npm:8.32.1, @typescript-eslint/parser@npm:^8.32.1":
   version: 8.32.1
   resolution: "@typescript-eslint/parser@npm:8.32.1"
   dependencies:
@@ -1498,6 +1498,7 @@ __metadata:
     svelte-check: "npm:^4.2.1"
     tslib: "npm:^2.8.1"
     typescript: "npm:^5.8.3"
+    typescript-eslint: "npm:^8.32.1"
     vite: "npm:^6.3.5"
     wrangler: "npm:^4.15.2"
     xml-formatter: "npm:^3.6.6"
@@ -3866,6 +3867,20 @@ __metadata:
   dependencies:
     prelude-ls: "npm:^1.2.1"
   checksum: 10c0/7b3fd0ed43891e2080bf0c5c504b418fbb3e5c7b9708d3d015037ba2e6323a28152ec163bcb65212741fa5d2022e3075ac3c76440dbd344c9035f818e8ecee58
+  languageName: node
+  linkType: hard
+
+"typescript-eslint@npm:^8.32.1":
+  version: 8.32.1
+  resolution: "typescript-eslint@npm:8.32.1"
+  dependencies:
+    "@typescript-eslint/eslint-plugin": "npm:8.32.1"
+    "@typescript-eslint/parser": "npm:8.32.1"
+    "@typescript-eslint/utils": "npm:8.32.1"
+  peerDependencies:
+    eslint: ^8.57.0 || ^9.0.0
+    typescript: ">=4.8.4 <5.9.0"
+  checksum: 10c0/15602916b582b86c8b4371e99d5721c92af7ae56f9b49cd7971d2a49f11bf0bd64dd8d2c0e2b3ca87b2f3a6fd14966738121f3f8299de50c6109b9f245397f3b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- restrict allowed types for the `classnames` helper
- narrow `class` type on `Extract` component interface
- ignore palette CSS from prettier

## Testing
- `yarn lint` *(fails: Cannot find package 'typescript-eslint')*
- `yarn check`