### PR TITLE
Extract search highlight helper

### DIFF
--- a/src/helpers/highlight.ts
+++ b/src/helpers/highlight.ts
@@ -1,0 +1,49 @@
+/**
+ * Highlight occurrences of a search query within the page using the CSS
+ * `::highlight` API.
+ *
+ * @param query - Search term to highlight.
+ * @param target - Optional CSS selector, element or NodeList to search.
+ *                 Defaults to elements with the `.extract` class.
+ */
+export function highlightSearchResults(
+	query: string,
+	target: string | HTMLElement | NodeListOf<HTMLElement> = '.extract'
+) {
+	if (typeof document === 'undefined' || !CSS.highlights) return;
+
+	CSS.highlights.clear();
+
+	if (!query.trim()) return;
+
+	let elements: NodeListOf<HTMLElement> | HTMLElement[];
+	if (typeof target === 'string') {
+		elements = document.querySelectorAll<HTMLElement>(target);
+	} else if (target instanceof HTMLElement) {
+		elements = [target];
+	} else {
+		elements = Array.from(target);
+	}
+
+	const ranges: Range[] = [];
+	const lowerQuery = query.toLowerCase();
+
+	elements.forEach((el) => {
+		const walker = document.createTreeWalker(el, NodeFilter.SHOW_TEXT);
+		let node: Text | null;
+		while ((node = walker.nextNode() as Text | null)) {
+			const text = node.textContent?.toLowerCase() ?? '';
+			let match: RegExpExecArray | null;
+			const regex = new RegExp(lowerQuery, 'gi');
+			while ((match = regex.exec(text)) !== null) {
+				const range = new Range();
+				range.setStart(node, match.index);
+				range.setEnd(node, match.index + lowerQuery.length);
+				ranges.push(range);
+			}
+		}
+	});
+
+	const searchHighlight = new Highlight(...ranges);
+	CSS.highlights.set('search-results', searchHighlight);
+}

--- a/src/routes/search/+page.svelte
+++ b/src/routes/search/+page.svelte
@@ -2,6 +2,7 @@
 	import { page } from '$app/state';
 	import ExtractGallery from '$components/ExtractGallery.svelte';
 	import TextInput from '$components/TextInput.svelte';
+	import { highlightSearchResults } from '$helpers/highlight';
 
 	const { data } = $props();
 	const results = $derived(data.results);
@@ -23,37 +24,6 @@
 	function updateSearchValue(event: Event) {
 		const target = event.target as HTMLInputElement;
 		searchValue = target.value;
-	}
-
-	function highlightSearchResults(searchValue: string) {
-		if (!CSS.highlights) return; // Check for browser support
-
-		CSS.highlights.clear();
-
-		if (!searchValue.trim()) return;
-
-		const ranges: Range[] = [];
-		const extractElements = document.querySelectorAll('.extract');
-		const query = searchValue.toLowerCase();
-
-		extractElements.forEach((el) => {
-			const walker = document.createTreeWalker(el, NodeFilter.SHOW_TEXT);
-			let node: Text | null;
-			while ((node = walker.nextNode() as Text | null)) {
-				const text = node.textContent?.toLowerCase() ?? '';
-				let match: RegExpExecArray | null;
-				const regex = new RegExp(query, 'gi');
-				while ((match = regex.exec(text)) !== null) {
-					const range = new Range();
-					range.setStart(node, match.index);
-					range.setEnd(node, match.index + query.length);
-					ranges.push(range);
-				}
-			}
-		});
-
-		const searchHighlight = new Highlight(...ranges);
-		CSS.highlights.set('search-results', searchHighlight);
 	}
 </script>
 


### PR DESCRIPTION
## Summary
- add a `highlightSearchResults` helper for reusable search result highlighting
- use the helper in the search page
- revert README changes

## Testing
- `yarn lint` *(fails: Code style issues in `src/styles/palette.css`)*