### PR TITLE
Clean up helpers and simplify type handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "barnsworthburning",
 	"version": "5.0.0",
 	"type": "module",
-	"packageManager": "pnpm@10.29.1+sha512.48dae233635a645768a3028d19545cacc1688639eeb1f3734e42d6d6b971afbf22aa1ac9af52a173d9c3a20c15857cfa400f19994d79a2f626fcc73fccda9bbc",
+	"packageManager": "pnpm@10.29.3+sha512.498e1fb4cca5aa06c1dcf2611e6fafc50972ffe7189998c409e90de74566444298ffe43e6cd2acdc775ba1aa7cc5e092a8b7054c811ba8c5770f84693d33d2dc",
 	"engines": {
 		"node": "24.x"
 	},

--- a/src/helpers/cache.ts
+++ b/src/helpers/cache.ts
@@ -1,59 +1,36 @@
-/**
- * Cache control header configurations for different types of content
- */
-
 interface CacheConfig {
-	/**
-	 * Browser cache duration in seconds
-	 */
 	maxAge?: number;
-	/**
-	 * CDN cache duration in seconds
-	 */
 	sMaxAge?: number;
-	/**
-	 * Allow serving stale content while revalidating in background
-	 */
 	staleWhileRevalidate?: number;
-	/**
-	 * Cache can be stored by shared caches (CDN)
-	 */
 	public?: boolean;
 }
 
 const CACHE_CONFIGS = {
-	// For entity lists that change occasionally
 	entityList: {
-		maxAge: 60, // 1 minute browser cache
-		sMaxAge: 300, // 5 minutes CDN cache
-		staleWhileRevalidate: 86400, // 1 day stale-while-revalidate
+		maxAge: 60, // 1 min
+		sMaxAge: 300, // 5 min
+		staleWhileRevalidate: 86400, // 1 day
 		public: true
 	},
-	// For individual entities that change rarely
 	entity: {
-		maxAge: 300, // 5 minutes browser cache
-		sMaxAge: 3600, // 1 hour CDN cache
-		staleWhileRevalidate: 604800, // 1 week stale-while-revalidate
+		maxAge: 300, // 5 min
+		sMaxAge: 3600, // 1 hr
+		staleWhileRevalidate: 604800, // 1 week
 		public: true
 	},
-	// For search results that are dynamic
 	search: {
-		maxAge: 0, // No browser cache
-		sMaxAge: 60, // 1 minute CDN cache
-		staleWhileRevalidate: 300, // 5 minutes stale-while-revalidate
+		maxAge: 0,
+		sMaxAge: 60, // 1 min
+		staleWhileRevalidate: 300, // 5 min
 		public: true
 	},
-	// For feed that updates regularly
 	feed: {
-		maxAge: 0, // No browser cache
-		sMaxAge: 300, // 5 minutes CDN cache
+		maxAge: 0,
+		sMaxAge: 300, // 5 min
 		public: true
 	}
 } as const;
 
-/**
- * Generate cache control header string from config
- */
 function generateCacheControl(config: CacheConfig): string {
 	const parts: string[] = [];
 
@@ -76,9 +53,6 @@ function generateCacheControl(config: CacheConfig): string {
 	return parts.join(', ');
 }
 
-/**
- * Get cache headers for a specific cache type
- */
 export function getCacheHeaders(type: keyof typeof CACHE_CONFIGS): HeadersInit {
 	const config = CACHE_CONFIGS[type];
 	return {
@@ -87,9 +61,6 @@ export function getCacheHeaders(type: keyof typeof CACHE_CONFIGS): HeadersInit {
 	};
 }
 
-/**
- * Create a cached JSON response
- */
 export function cachedJson<T>(data: T, cacheType: keyof typeof CACHE_CONFIGS = 'entity'): Response {
 	return new Response(JSON.stringify(data), {
 		headers: {

--- a/src/helpers/cookies.ts
+++ b/src/helpers/cookies.ts
@@ -1,27 +1,15 @@
-export function getCookie<T = string>(name: string): T | undefined {
-	if (typeof document === 'undefined') {
-		// We're on the server, return undefined.
-		return undefined;
+export function getCookie(name: string): string | undefined {
+	if (typeof document === 'undefined') return undefined;
+
+	for (const pair of document.cookie.split(';')) {
+		const [key, value] = pair.split('=').map((s) => s.trim());
+		if (name === key) return decodeURIComponent(value);
 	}
 
-	const cookieArr = document.cookie.split(';');
-	for (let i = 0; i < cookieArr.length; i++) {
-		const cookiePair = cookieArr[i].split('=').map((cookie) => cookie.trim());
-
-		if (name == cookiePair[0]) {
-			return decodeURIComponent(cookiePair[1]) as T;
-		}
-	}
-	// Return undefined if the cookie by name does not exist.
 	return undefined;
 }
 
 export function setCookie(name: string, value: string) {
-	if (typeof document === 'undefined') {
-		// We're on the server, do nothing.
-		return;
-	}
-
-	const expires = 'Fri, 31 Dec 9999 23:59:59 GMT';
-	document.cookie = `${name}=${value || ''}; expires=${expires}; path=/`;
+	if (typeof document === 'undefined') return;
+	document.cookie = `${name}=${value || ''}; expires=Fri, 31 Dec 9999 23:59:59 GMT; path=/`;
 }

--- a/src/helpers/grammar.ts
+++ b/src/helpers/grammar.ts
@@ -12,19 +12,10 @@ export const capitalize = (string?: string) => {
 	return string.charAt(0).toUpperCase() + string.slice(1);
 };
 
-export const toTitleCase = (str: string) => {
-	// Convert the entire string to lowercase first to ensure consistency
-	return str.toLowerCase().replace(/\b\w+\b/g, capitalize);
-};
+export const toTitleCase = (str: string) => str.toLowerCase().replace(/\b\w+\b/g, capitalize);
 
 export const combineAsList = (arr: string[], transformer?: (txt: string) => string) => {
 	const mapped = transformer ? arr.map(transformer) : arr;
-	if (mapped.length === 0) {
-		return ''; // Return an empty string if no elements exist
-	}
-	if (mapped.length === 1) {
-		return arr[0]; // Return the single entry if only one element exists
-	}
-	const lastElement = mapped.pop(); // Remove the last element from the array
-	return mapped.join(', ') + ' & ' + lastElement; // Join with commas and last with an ampersand
+	if (mapped.length <= 1) return mapped[0] ?? '';
+	return mapped.slice(0, -1).join(', ') + ' & ' + mapped.at(-1);
 };

--- a/src/helpers/highlight.ts
+++ b/src/helpers/highlight.ts
@@ -1,10 +1,6 @@
 /**
- * Highlight occurrences of a search query within the page using the CSS
- * `::highlight` API.
- *
- * @param query - Search term to highlight.
- * @param target - Optional CSS selector, element or NodeList to search.
- *                 Defaults to elements with the `.extract` class.
+ * Highlight occurrences of a search query using the CSS `::highlight` API.
+ * Defaults to elements with the `.extract` class.
  */
 export function highlightSearchResults(
 	query: string,
@@ -26,19 +22,18 @@ export function highlightSearchResults(
 	}
 
 	const ranges: Range[] = [];
-	const lowerQuery = query.toLowerCase();
 
 	elements.forEach((el) => {
 		const walker = document.createTreeWalker(el, NodeFilter.SHOW_TEXT);
-		let node: Text | null;
-		while ((node = walker.nextNode() as Text | null)) {
-			const text = node.textContent?.toLowerCase() ?? '';
+		let node: Node | null;
+		while ((node = walker.nextNode())) {
+			const text = node.textContent ?? '';
 			let match: RegExpExecArray | null;
-			const regex = new RegExp(lowerQuery, 'gi');
+			const regex = new RegExp(query, 'gi');
 			while ((match = regex.exec(text)) !== null) {
 				const range = new Range();
 				range.setStart(node, match.index);
-				range.setEnd(node, match.index + lowerQuery.length);
+				range.setEnd(node, match.index + query.length);
 				ranges.push(range);
 			}
 		}

--- a/src/helpers/images.ts
+++ b/src/helpers/images.ts
@@ -1,12 +1,9 @@
 import type { IExtract } from '$types/Airtable';
 
 export const findFirstImageUrl = (extracts?: IExtract[]): string | null => {
-	if (extracts && extracts.length > 0) {
-		for (const extract of extracts) {
-			if (extract.images && extract.images.length > 0) {
-				return extract.images[0].url;
-			}
-		}
+	if (!extracts) return null;
+	for (const extract of extracts) {
+		if (extract.images?.length) return extract.images[0].url;
 	}
 	return null;
 };

--- a/src/helpers/markdown.ts
+++ b/src/helpers/markdown.ts
@@ -1,10 +1,7 @@
 import { Marked, type Tokens } from 'marked';
 
-const linkRenderer = ({ href, title, text }: Tokens.Link) => {
-	const target = '_blank';
-	const titleTag = title ? ` title="${title}"` : '';
-	return `<a href="${href}" target="${target}"${titleTag}>${text}</a>`;
-};
+const linkRenderer = ({ href, title, text }: Tokens.Link) =>
+	`<a href="${href}" target="_blank"${title ? ` title="${title}"` : ''}>${text}</a>`;
 
 const markdown = new Marked({
 	breaks: true,

--- a/src/helpers/params.ts
+++ b/src/helpers/params.ts
@@ -59,29 +59,20 @@ export const decodeSegment = (segment = ''): Segment | undefined => {
 	};
 };
 
-export const decodeTrail = (trail: string = ''): Segment[] =>
+export const decodeTrail = (trail = ''): Segment[] =>
 	trail
 		.split('/')
-		.map((segment) => decodeSegment(segment))
-		.filter(Boolean) as Segment[];
+		.map(decodeSegment)
+		.filter((segment): segment is Segment => segment !== undefined);
 
 export const encodeTrail = (segments: Segment[]): string =>
 	'/' + segments.map((segment) => encodeSegment(segment.entityType, segment.id)).join('/');
 
-export const slugify = (title: string) => {
-	// Trim leading and trailing whitespace
-	let slug = title.trim();
-
-	// Convert to lowercase
-	slug = slug.toLowerCase();
-
-	// Remove all characters that are not letters, numbers, spaces, or hyphens
-	slug = slug.replace(/[^a-z0-9\s-]/g, '');
-
-	// Replace one or more spaces with a single hyphen
-	slug = slug.replace(/\s+/g, '-');
-
-	return slug;
-};
+export const slugify = (title: string) =>
+	title
+		.trim()
+		.toLowerCase()
+		.replace(/[^a-z0-9\s-]/g, '')
+		.replace(/\s+/g, '-');
 
 export const recordIdRegex = /^rec[a-zA-Z0-9]{14}$/;

--- a/src/lib/settings.svelte.ts
+++ b/src/lib/settings.svelte.ts
@@ -7,11 +7,9 @@ const CHROMA_COOKIE = THEME_CONFIG.cookies.chroma;
 const PALETTE_COOKIE = THEME_CONFIG.cookies.palette;
 
 export function createSettings() {
-	// During SSR or initial client render, read from DOM classes if available
-	// This ensures we get the values set by themePreferences.js
 	const getInitialValue = <T extends string>(
 		enumObj: Record<string, T>,
-		cookieValue: T | undefined,
+		cookieValue: string | undefined,
 		defaultValue: T
 	): T => {
 		if (typeof document !== 'undefined' && document.documentElement) {
@@ -22,16 +20,13 @@ export function createSettings() {
 				}
 			}
 		}
-		// If no DOM value found, use cookie value or default
-		return cookieValue ?? defaultValue;
+		return Object.values(enumObj).find((v) => v === cookieValue) ?? defaultValue;
 	};
 
-	// Get cookie values
-	const modeCookie = getCookie<Mode>(MODE_COOKIE);
-	const chromaCookie = getCookie<Chroma>(CHROMA_COOKIE);
-	const paletteCookie = getCookie<Palette>(PALETTE_COOKIE);
+	const modeCookie = getCookie(MODE_COOKIE);
+	const chromaCookie = getCookie(CHROMA_COOKIE);
+	const paletteCookie = getCookie(PALETTE_COOKIE);
 
-	// Use DOM values if available (from themePreferences.js), otherwise cookies, otherwise defaults
 	let mode = $state(getInitialValue(Mode, modeCookie, DEFAULT_MODE));
 	let chroma = $state(getInitialValue(Chroma, chromaCookie, DEFAULT_CHROMA));
 	let palette = $state(getInitialValue(Palette, paletteCookie, DEFAULT_PALETTE));


### PR DESCRIPTION
Bumped pnpm to 10.29.3 and cleaned up helper modules. Removed excessive documentation comments in favor of self-documenting code, simplified utility functions, and improved type safety throughout.

Specific changes:
- Replaced generic `zip` function with narrowly-scoped `zipRecords` for linked record mapping
- Simplified several helpers: `cookies.ts`, `grammar.ts`, `images.ts`, `params.ts`, and `markdown.ts`
- Removed verbose JSDoc comments in `cache.ts` and other modules where intent is clear from code
- Fixed type safety issues in cookie handling (`getCookie` now has proper return types)
- Refactored `combineAsList`, `decodeTrail`, and `slugify` to be more concise
- Updated highlight search function for clarity