### PR TITLE
Show quotes and replies before the labeled relation groups

### DIFF
--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -1,0 +1,11 @@
+"$schema" = "https://conductor.build/schemas/settings.repo.schema.json"
+
+[scripts]
+run_mode = "concurrent"
+setup = "bun install"
+
+[scripts.run.dev]
+available_in = [ "local" ]
+command = "bun run dev --port $CONDUCTOR_PORT"
+default = true
+icon = "play"

--- a/src/routes/app/RecordItem.svelte
+++ b/src/routes/app/RecordItem.svelte
@@ -22,6 +22,10 @@
 	<article>
 		<RecordCard {record} class="chromatic" variant="card" suppressBlockLink />
 
+		{#each children as child (child.id)}
+			<RecordCard record={child} suppressBlockLink />
+		{/each}
+
 		{#each references as group (group.label)}
 			<section class="reference-group">
 				<div class="connections-separator" role="presentation">
@@ -31,10 +35,6 @@
 				</div>
 				<RecordList records={group.records} />
 			</section>
-		{/each}
-
-		{#each children as child (child.id)}
-			<RecordCard record={child} suppressBlockLink />
 		{/each}
 
 		{#if similar.length > 0}


### PR DESCRIPTION
On an artifact's page, quotes and replies rendered below every labeled group, and the "related to" group renders last among those, so a reply visually attached to the "related to" list above it. Children now render directly under the record card, with the labeled groups and "see also" following.

Also adds a shared Conductor config. The machine-local one predated the bun migration and its `pnpm install` setup script dropped a stray `pnpm-lock.yaml` into every new workspace. The shared config installs with bun and runs the dev server on the workspace's allocated port, so parallel workspaces don't collide.