### PR TITLE
Restore the mobile nav spacing and stack the search filters

### DIFF
--- a/src/routes/search/+page.svelte
+++ b/src/routes/search/+page.svelte
@@ -80,8 +80,8 @@
 	.toolbar {
 		margin-block-end: 1em;
 		display: flex;
-		align-items: center;
-		gap: 1.5em;
+		flex-direction: column;
+		gap: 0.75em;
 
 		.search-input {
 			display: flex;

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -122,8 +122,10 @@
 			flex: 1 0 0;
 			display: flex;
 			flex-direction: column;
-			gap: 0;
+			gap: 0.5em;
 			align-items: center;
+			height: auto;
+			padding-block: 0.5em;
 		}
 	}
 	.app-toolbar {


### PR DESCRIPTION
The rcr migration (#65) gave nav links a fixed 2em height and replaced the emoji icons, whose tall line boxes had supplied all of the floating mobile nav's vertical spacing, so the stacked icon and label ended up crushed against the bar's edges. Restores the pre-migration proportions by releasing the height in the mobile layout and giving the column explicit block padding and an icon-to-label gap. Also stacks the search page toolbar so the type filters sit below the search input instead of beside it.