### PR TITLE
Fade the index at its scroll edges

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -133,7 +133,7 @@
 		</main>
 	{/if}
 	<hr />
-	<footer class="app-footer">
+	<footer class="app-footer scroll-fade">
 		<Index entries={indexEntries} class="app-index" />
 	</footer>
 </div>

--- a/src/styles/utilities.css
+++ b/src/styles/utilities.css
@@ -65,3 +65,59 @@
 .paper {
 	background-color: var(--paper);
 }
+
+@property --scroll-fade-start {
+	syntax: '<length-percentage>';
+	inherits: false;
+	initial-value: 0px;
+}
+
+@property --scroll-fade-end {
+	syntax: '<length-percentage>';
+	inherits: false;
+	initial-value: 0px;
+}
+
+@keyframes scroll-fade-reveal-start {
+	from {
+		--scroll-fade-start: 0px;
+	}
+	to {
+		--scroll-fade-start: var(--scroll-fade-size, min(12%, 2.5rem));
+	}
+}
+
+@keyframes scroll-fade-reveal-end {
+	from {
+		--scroll-fade-end: var(--scroll-fade-size, min(12%, 2.5rem));
+	}
+	to {
+		--scroll-fade-end: 0px;
+	}
+}
+
+.scroll-fade {
+	mask-image: linear-gradient(
+		to bottom,
+		transparent 0,
+		#000 var(--scroll-fade-start),
+		#000 calc(100% - var(--scroll-fade-end)),
+		transparent 100%
+	);
+
+	@supports (animation-timeline: scroll()) {
+		animation:
+			scroll-fade-reveal-start 1ms ease-in-out,
+			scroll-fade-reveal-end 1ms ease-in-out;
+		animation-timeline: scroll(self block), scroll(self block);
+		animation-range:
+			0 var(--scroll-fade-reveal, 6rem),
+			calc(100% - var(--scroll-fade-reveal, 6rem)) 100%;
+		animation-fill-mode: both;
+	}
+
+	@supports not (animation-timeline: scroll()) {
+		--scroll-fade-start: var(--scroll-fade-size, min(12%, 2.5rem));
+		--scroll-fade-end: var(--scroll-fade-size, min(12%, 2.5rem));
+	}
+}


### PR DESCRIPTION
The index list cuts off abruptly where it scrolls, with no hint that more entries continue past the edge.

Adds a `scroll-fade` utility to `utilities.css`, a plain-CSS port of [shadcn's scroll-fade](https://ui.shadcn.com/docs/utils/scroll-fade): registered custom properties driven by two scroll-timeline animations feed a `mask-image` gradient, so an edge fades only while content remains beyond it and sharpens at rest. Containers that don't overflow render no fade at all, and browsers without scroll-driven animations fall back to a static fade on both edges. The fade depth and reveal distance stay overridable per container via `--scroll-fade-size` and `--scroll-fade-reveal`.

Applies the class to the app footer, the scroll container for the index in both desktop layouts (the sidebar column on record pages and the centered column on the index page). On mobile the footer doesn't scroll, so nothing changes there.