### PR TITLE
Dock quoted and responded-to works on the record card

### DIFF
--- a/src/components/RecordAttachment.svelte
+++ b/src/components/RecordAttachment.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import markdown from '#helpers/markdown.js';
-	import { displayTitle, type RecordLink } from '#lib/records.js';
+	import type { RecordLink } from '#lib/records.js';
 	import CreatorList from './CreatorList.svelte';
 	import Link from './Link.svelte';
 
@@ -14,16 +14,22 @@
 	let { record, dock, relation, preview = null }: RecordAttachmentProps = $props();
 </script>
 
-<section class="extract-attachment" data-dock={dock} data-relation={relation}>
-	<div class="attachment-heading">
-		<strong class="attachment-title"><Link {record} inherit>{displayTitle(record)}</Link></strong>
-		{#if record.creators.length > 0}
-			<CreatorList class="attachment-creators" creators={record.creators} />
+{#if record.title || record.creators.length > 0 || preview}
+	<section class="extract-attachment" data-dock={dock} data-relation={relation}>
+		{#if record.title || record.creators.length > 0}
+			<div class="attachment-heading">
+				{#if record.title}
+					<strong class="attachment-title"><Link {record} inherit>{record.title}</Link></strong>
+				{/if}
+				{#if record.creators.length > 0}
+					<CreatorList class="attachment-creators" creators={record.creators} />
+				{/if}
+			</div>
 		{/if}
-	</div>
-	{#if preview}
-		<div class="attachment-preview content">
-			{@html markdown.parsePreview(preview)}
-		</div>
-	{/if}
-</section>
+		{#if preview}
+			<div class="attachment-preview content">
+				{@html markdown.parsePreview(preview)}
+			</div>
+		{/if}
+	</section>
+{/if}

--- a/src/components/RecordAttachment.svelte
+++ b/src/components/RecordAttachment.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+	import markdown from '#helpers/markdown.js';
+	import { displayTitle, type RecordLink } from '#lib/records.js';
+	import CreatorList from './CreatorList.svelte';
+	import Link from './Link.svelte';
+
+	interface RecordAttachmentProps {
+		record: RecordLink & { creators: RecordLink[] };
+		dock: 'top' | 'bottom';
+		relation: 'container' | 'response' | 'quote';
+		preview?: string | null;
+	}
+
+	let { record, dock, relation, preview = null }: RecordAttachmentProps = $props();
+</script>
+
+<section class="extract-attachment" data-dock={dock} data-relation={relation}>
+	<div class="attachment-heading">
+		<strong class="attachment-title"><Link {record} inherit>{displayTitle(record)}</Link></strong>
+		{#if record.creators.length > 0}
+			<CreatorList class="attachment-creators" creators={record.creators} />
+		{/if}
+	</div>
+	{#if preview}
+		<div class="attachment-preview content">
+			{@html markdown.parsePreview(preview)}
+		</div>
+	{/if}
+</section>

--- a/src/components/RecordCard.svelte
+++ b/src/components/RecordCard.svelte
@@ -126,12 +126,12 @@
 				{/if}
 			</nav>
 		{/if}
+		{#if record.notes}
+			<footer class="extract-notes content">
+				{@html markdown.parse(record.notes)}
+			</footer>
+		{/if}
 	</section>
-	{#if record.notes}
-		<footer class="extract-footer content">
-			{@html markdown.parse(record.notes)}
-		</footer>
-	{/if}
 	{#each record.quoted as quote (quote.id)}
 		<RecordAttachment record={quote} dock="bottom" relation="quote" preview={quote.preview} />
 	{/each}

--- a/src/components/RecordCard.svelte
+++ b/src/components/RecordCard.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { classnames } from '#helpers/classnames.js';
 	import markdown from '#helpers/markdown.js';
-	import { displayTitle, visualMedia, type RecordCard } from '#lib/records.js';
+	import { visualMedia, type RecordCard } from '#lib/records.js';
 	import { PUBLIC_RCR_URL } from '$app/env/public';
 	import {
 		ArrowLeftRightIcon,
@@ -12,8 +12,8 @@
 	import type { HTMLAttributes } from 'svelte/elements';
 	import BlockLink from './BlockLink.svelte';
 	import Citation from './Citation.svelte';
-	import CreatorList from './CreatorList.svelte';
 	import Link from './Link.svelte';
+	import RecordAttachment from './RecordAttachment.svelte';
 	import RecordMedia from './RecordMedia.svelte';
 	import RelationList from './RelationList.svelte';
 	import TopicList from './TopicList.svelte';
@@ -56,14 +56,15 @@
 	suppress={suppressBlockLink}
 >
 	{#each record.parents as parent (parent.id)}
-		<section class="extract-parent">
-			<strong class="parent-title"
-				><Link record={parent} inherit>{displayTitle(parent)}</Link></strong
-			>
-			{#if parent.creators.length > 0}
-				<CreatorList class="parent-creators" creators={parent.creators} />
-			{/if}
-		</section>
+		<RecordAttachment record={parent} dock="top" relation="container" />
+	{/each}
+	{#each record.respondsTo as responded (responded.id)}
+		<RecordAttachment
+			record={responded}
+			dock="top"
+			relation="response"
+			preview={responded.preview}
+		/>
 	{/each}
 	<section class="extract-body">
 		{#if record.title}
@@ -131,4 +132,7 @@
 			{@html markdown.parse(record.notes)}
 		</footer>
 	{/if}
+	{#each record.quoted as quote (quote.id)}
+		<RecordAttachment record={quote} dock="bottom" relation="quote" preview={quote.preview} />
+	{/each}
 </BlockLink>

--- a/src/helpers/markdown.ts
+++ b/src/helpers/markdown.ts
@@ -12,5 +12,11 @@ const markdown = new Marked({
 
 export default {
 	parse: (source: string) => markdown.parse(source, { async: false }),
-	parseInline: (source: string) => markdown.parseInline(source, { async: false })
+	parseInline: (source: string) => markdown.parseInline(source, { async: false }),
+	parsePreview: (source: string) =>
+		markdown
+			.parse(source, { async: false })
+			.toString()
+			.replaceAll('<br>', '<span class="line-break"></span>')
+			.replaceAll(/<a(?:\s+[^>]*)?>([^<]*)<\/a>/g, '$1')
 };

--- a/src/lib/records.ts
+++ b/src/lib/records.ts
@@ -18,6 +18,11 @@ export interface LinkGroup {
 	records: RecordLink[];
 }
 
+export interface RecordAttachment extends RecordLink {
+	creators: RecordLink[];
+	preview: string | null;
+}
+
 export interface RecordCard extends RecordFields {
 	media: MediaSelect[];
 	creators: RecordLink[];
@@ -25,6 +30,8 @@ export interface RecordCard extends RecordFields {
 	tags: RecordLink[];
 	format: RecordLink | null;
 	parents: (RecordLink & { creators: RecordLink[] })[];
+	quoted: RecordAttachment[];
+	respondsTo: RecordAttachment[];
 	children: RecordLink[];
 	childPreview: string | null;
 	childMedia: MediaSelect | null;

--- a/src/lib/server/records.ts
+++ b/src/lib/server/records.ts
@@ -41,12 +41,19 @@ const describingPredicates: PredicateSlug[] = [
 	'responds_to'
 ];
 
-/** Containment links frame the card: outgoing targets (the container, the quoted work) render above the record, incoming sources render below as children. */
+/** Containment links frame the card: the container and responded-to work attach above the record, quoted works attach below, and incoming sources render beneath as children. */
 const containmentPredicates: PredicateSlug[] = ['contained_by', 'quotes'];
 
 /** Predicate/direction pairs the card shape models with dedicated fields. */
 const modeledPredicates: Record<LinkGroup['direction'], PredicateSlug[]> = {
-	outgoing: ['created_by', 'tagged_with', 'has_format', ...containmentPredicates, 'related_to'],
+	outgoing: [
+		'created_by',
+		'tagged_with',
+		'has_format',
+		...containmentPredicates,
+		'responds_to',
+		'related_to'
+	],
 	incoming: [...containmentPredicates, 'related_to']
 };
 
@@ -101,9 +108,17 @@ const linkColumns = {
 	recordCreatedAt: true
 } as const;
 
+const previewColumns = {
+	...linkColumns,
+	summary: true,
+	content: true,
+	mediaCaption: true,
+	notes: true
+} as const;
+
 const sourceWith = {
 	source: {
-		columns: { ...linkColumns, summary: true, content: true, mediaCaption: true, notes: true },
+		columns: previewColumns,
 		with: { media: { orderBy: { id: 'asc' } } }
 	}
 } as const;
@@ -115,7 +130,7 @@ const cardWith = {
 	outgoingLinks: {
 		with: {
 			target: {
-				columns: linkColumns,
+				columns: previewColumns,
 				with: {
 					outgoingLinks: {
 						where: { predicate: 'created_by' },
@@ -159,15 +174,19 @@ const byBestLink = (a: LinkRowRecord, b: LinkRowRecord) =>
 const byChronologyLink = (a: LinkRowRecord, b: LinkRowRecord) =>
 	linkDate(a) - linkDate(b) || a.id - b.id;
 
-type SourceRow = LinkRowRecord &
-	Pick<RecordFields, 'summary' | 'content' | 'mediaCaption' | 'notes'> & { media: MediaSelect[] };
+type PreviewRow = LinkRowRecord &
+	Pick<RecordFields, 'summary' | 'content' | 'mediaCaption' | 'notes'>;
+
+type SourceRow = PreviewRow & { media: MediaSelect[] };
+
+type TargetRow = PreviewRow & { outgoingLinks: { target: LinkRowRecord | null }[] };
 
 interface CardRow extends RecordFields {
 	media: MediaSelect[];
 	outgoingLinks: {
 		id: number;
 		predicate: string;
-		target: (LinkRowRecord & { outgoingLinks: { target: LinkRowRecord | null }[] }) | null;
+		target: TargetRow | null;
 	}[];
 	incomingLinks: {
 		id: number;
@@ -209,21 +228,30 @@ function toCard(row: CardRow): RecordCard {
 			.flatMap((link) => (link.predicate === predicate && guard(link.source) ? [link.source] : []))
 			.sort(byBestLink);
 
-	const parents = dedupeById(
-		containmentPredicates
-			.flatMap((predicate) =>
-				outgoingLinks.flatMap((link) =>
-					link.predicate === predicate && isListable(link.target) ? [link.target] : []
+	// Quoted and responded-to works keep titleless targets: the attachment's
+	// preview lines identify them where a bare link could not.
+	const attachmentRows = (predicate: PredicateSlug, guard: typeof isListable = isListable) =>
+		dedupeById(
+			outgoingLinks
+				.flatMap((link) =>
+					link.predicate === predicate && guard(link.target) ? [link.target] : []
 				)
-			)
-			.sort(byBestLink)
-			.map((target) => ({
-				...pickLink(target),
-				creators: target.outgoingLinks.flatMap((nested) =>
-					isListable(nested.target) ? [pickLink(nested.target)] : []
-				)
-			}))
-	);
+				.sort(byBestLink)
+		);
+	const withCreators = (target: TargetRow) => ({
+		...pickLink(target),
+		creators: target.outgoingLinks.flatMap((nested) =>
+			isListable(nested.target) ? [pickLink(nested.target)] : []
+		)
+	});
+	const toAttachment = (target: TargetRow) => ({
+		...withCreators(target),
+		preview: recordPreview(target)
+	});
+
+	const parents = attachmentRows('contained_by').map(withCreators);
+	const quoted = attachmentRows('quotes', isVisible).map(toAttachment);
+	const respondsTo = attachmentRows('responds_to', isVisible).map(toAttachment);
 
 	// Connections keep the order their links were added in — the earliest links
 	// are typically the most relevant.
@@ -293,6 +321,8 @@ function toCard(row: CardRow): RecordCard {
 		tags: targets('tagged_with').map(pickLink),
 		format: targets('has_format').map(pickLink)[0] ?? null,
 		parents,
+		quoted,
+		respondsTo,
 		children: childRows.map(pickLink),
 		childPreview: containedRows.map(recordPreview).find(Boolean) ?? null,
 		childMedia: containedRows.flatMap((child) => visualMedia(child.media))[0] ?? null,
@@ -432,6 +462,7 @@ export async function getSimilarRecords(id: number): Promise<RecordCard[]> {
 	const rows = await db.query.records.findMany({
 		where: {
 			...isListed,
+			type: 'artifact',
 			id: { notIn: linkedIds },
 			textEmbedding: { isNotNull: true },
 			...(parentIds.length > 0

--- a/src/routes/app/RecordList.svelte
+++ b/src/routes/app/RecordList.svelte
@@ -46,11 +46,7 @@
 					</header>
 					{#if snippet}
 						<blockquote class="summary">
-							{@html markdown
-								.parse(snippet)
-								.toString()
-								.replaceAll('<br>', '<span class="line-break"></span>')
-								.replaceAll(/<a(?:\s+[^>]*)?>([^<]*)<\/a>/g, '$1')}
+							{@html markdown.parsePreview(snippet)}
 						</blockquote>
 					{:else if record.abbreviation || record.sense}
 						<p class="summary">

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -147,8 +147,7 @@
 		background-color: transparent;
 
 		.extract-attachment,
-		.extract-body,
-		.extract-footer {
+		.extract-body {
 			padding-inline: 0;
 			padding-block: 0;
 		}
@@ -162,7 +161,6 @@
 			padding-block-end: var(--container-padding-block);
 		}
 
-		.extract-footer,
 		.extract-attachment[data-dock='bottom'] {
 			margin-block-start: var(--container-padding-block);
 			padding-block-start: var(--container-padding-block);
@@ -170,22 +168,17 @@
 	}
 
 	.extract-attachment,
-	.extract-body,
-	.extract-footer {
+	.extract-body {
 		padding-inline: var(--container-padding-inline);
 	}
 
-	.extract-attachment,
-	.extract-footer {
-		padding-block: calc(var(--container-padding-block) / 1.5);
-		font-size: var(--font-size-small);
-	}
-
 	.extract-attachment {
-		color: var(--accent);
 		display: flex;
 		flex-direction: column;
 		gap: calc(var(--layout-gap) / 2);
+		padding-block: calc(var(--container-padding-block) / 1.5);
+		font-size: var(--font-size-small);
+		color: var(--accent);
 
 		&[data-dock='top'] {
 			border-block-end: 1px solid var(--divider);
@@ -231,9 +224,9 @@
 		}
 	}
 
-	.extract-footer {
+	.extract-notes {
 		color: var(--secondary);
-		border-block-start: 1px solid var(--divider);
+		font-size: var(--font-size-small);
 	}
 
 	.extract-body {

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -146,54 +146,88 @@
 		border-radius: 0;
 		background-color: transparent;
 
-		.extract-parent,
+		.extract-attachment,
 		.extract-body,
 		.extract-footer {
 			padding-inline: 0;
 			padding-block: 0;
 		}
 
-		.extract-parent {
+		.extract-attachment[data-relation='container'] {
 			display: none;
 		}
 
-		.extract-footer {
+		.extract-attachment[data-dock='top'] {
+			margin-block-end: var(--container-padding-block);
+			padding-block-end: var(--container-padding-block);
+		}
+
+		.extract-footer,
+		.extract-attachment[data-dock='bottom'] {
 			margin-block-start: var(--container-padding-block);
 			padding-block-start: var(--container-padding-block);
 		}
 	}
 
-	.extract-parent,
+	.extract-attachment,
 	.extract-body,
 	.extract-footer {
 		padding-inline: var(--container-padding-inline);
 	}
 
-	.extract-parent,
+	.extract-attachment,
 	.extract-footer {
 		padding-block: calc(var(--container-padding-block) / 1.5);
 		font-size: var(--font-size-small);
 	}
 
-	.extract-parent {
+	.extract-attachment {
 		color: var(--accent);
-		border-block-end: 1px solid var(--divider);
 		display: flex;
-		gap: var(--layout-gap);
+		flex-direction: column;
+		gap: calc(var(--layout-gap) / 2);
 
-		& > * {
-			white-space: nowrap;
+		&[data-dock='top'] {
+			border-block-end: 1px solid var(--divider);
+		}
+
+		&[data-dock='bottom'] {
+			border-block-start: 1px solid var(--divider);
+		}
+
+		.attachment-heading {
+			display: flex;
+			gap: var(--layout-gap);
+
+			& > * {
+				white-space: nowrap;
+				overflow: hidden;
+				text-overflow: ellipsis;
+			}
+
+			& > .attachment-title {
+				flex: 0 1 auto;
+			}
+
+			& > .attachment-creators {
+				flex: 1;
+				min-width: 25%;
+			}
+		}
+
+		.attachment-preview {
+			color: var(--secondary);
+			display: -webkit-box;
+			-webkit-box-orient: vertical;
+			-webkit-line-clamp: 3;
+			line-clamp: 3;
 			overflow: hidden;
-			text-overflow: ellipsis;
-		}
 
-		& > .parent-title {
-			flex: 0 1 auto;
-		}
-
-		& > .parent-creators {
-			flex: 1;
-			min-width: 25%;
+			.line-break::after {
+				content: '/';
+				margin-inline: 0.5ch;
+				color: var(--hint);
+			}
 		}
 	}
 


### PR DESCRIPTION
A record that quotes another work rendered that work in the parent bar at the top of its card, indistinguishable from its container, and the target of a reply appeared only in a labeled reference group. Both relationships now dock to the card frame as their own strips, the way a quote tweet embeds the tweet it quotes.

- Adds `RecordAttachment`, a shared strip that attaches outside the card body: title and creators, plus a content preview clamped to three lines when the relationship calls for one.
- Containers (`contained_by`) keep the one-line bar above the card. Responded-to works (`responds_to`) dock above with a preview, and quoted works (`quotes`) dock below, after everything else in the card.
- Quote and reply attachments keep titleless targets (mostly tweets): the heading renders only what exists (title, creators, or neither) and the preview carries the identification. Containers still require a title.

Narrowing the parent bar to `contained_by` also corrects two spots that treated a quoted work as a container: the feed citation no longer says "from *X*" when X is merely quoted, and the SEO creator fallback no longer attributes a quoting note to the quoted author. Attachment previews get the same markdown treatment as the artifacts-list snippets (line breaks flattened to "/", anchors stripped to text), now shared as `markdown.parsePreview`.

A couple other small changes: user notes move inside the card body under the tags, so they no longer mimic the quoted strip's divider styling, and See Also recommends only artifacts, never entities or concepts.