### PR TITLE
Hide attachments that point back at the record in view

### DIFF
--- a/src/components/RecordCard.svelte
+++ b/src/components/RecordCard.svelte
@@ -23,7 +23,7 @@
 	> {
 		record: RecordCard;
 		element?: T;
-		suppressBlockLink?: boolean;
+		pageRecordId?: number;
 		variant?: 'default' | 'card';
 		class?: string;
 	}
@@ -31,10 +31,13 @@
 	let {
 		record,
 		element = 'article',
-		suppressBlockLink = false,
+		pageRecordId,
 		class: className,
 		variant = 'default'
 	}: RecordCardProps<keyof HTMLElementTagNameMap> = $props();
+
+	let quoted = $derived(record.quoted.filter((target) => target.id !== pageRecordId));
+	let respondsTo = $derived(record.respondsTo.filter((target) => target.id !== pageRecordId));
 
 	let mediaItems = $derived(visualMedia(record.media));
 	// The title carries the link, so titleless children can't render as chips;
@@ -53,12 +56,12 @@
 <BlockLink
 	{element}
 	class={classnames('extract', `extract--${variant}`, 'ssm-container', className)}
-	suppress={suppressBlockLink}
+	suppress={pageRecordId !== undefined}
 >
 	{#each record.parents as parent (parent.id)}
 		<RecordAttachment record={parent} dock="top" relation="container" />
 	{/each}
-	{#each record.respondsTo as responded (responded.id)}
+	{#each respondsTo as responded (responded.id)}
 		<RecordAttachment
 			record={responded}
 			dock="top"
@@ -132,7 +135,7 @@
 			</footer>
 		{/if}
 	</section>
-	{#each record.quoted as quote (quote.id)}
+	{#each quoted as quote (quote.id)}
 		<RecordAttachment record={quote} dock="bottom" relation="quote" preview={quote.preview} />
 	{/each}
 </BlockLink>

--- a/src/routes/app/RecordItem.svelte
+++ b/src/routes/app/RecordItem.svelte
@@ -20,10 +20,10 @@
 
 {#if record.type === 'artifact'}
 	<article>
-		<RecordCard {record} class="chromatic" variant="card" suppressBlockLink />
+		<RecordCard {record} class="chromatic" variant="card" pageRecordId={record.id} />
 
 		{#each children as child (child.id)}
-			<RecordCard record={child} suppressBlockLink />
+			<RecordCard record={child} pageRecordId={record.id} />
 		{/each}
 
 		{#each references as group (group.label)}


### PR DESCRIPTION
In the trail, a note that quotes the open record repeated that record as a strip at the bottom of its own card, directly under the full card it duplicates. Cards rendered as page content now drop attachments whose target is the page's own record, while attachments to any other work still show. The page-content marker (`pageRecordId`) replaces the block-link flag (`suppressBlockLink`), since a card is un-clickable page content and context-redundant in exactly the same places.