### PR TITLE
Surface every relation on the card and collect every link in galleries

### DIFF
--- a/src/components/RecordCard.svelte
+++ b/src/components/RecordCard.svelte
@@ -1,14 +1,22 @@
 <script lang="ts">
 	import { classnames } from '#helpers/classnames.js';
 	import markdown from '#helpers/markdown.js';
-	import { visualMedia, type RecordCard } from '#lib/records.js';
+	import { visualMedia, type RecordCard, type RecordLink } from '#lib/records.js';
 	import { PUBLIC_RCR_URL } from '$app/env/public';
+	import type { PredicateSlug } from '@aias/hozo';
 	import {
 		ArrowLeftRightIcon,
 		ArrowRightIcon,
+		AtSignIcon,
 		CloudIcon,
 		CornerDownRightIcon,
-		ListCollapseIcon
+		CrosshairIcon,
+		EqualIcon,
+		ListCollapseIcon,
+		PenLineIcon,
+		ReplyIcon,
+		SwordsIcon,
+		type LucideIcon
 	} from '@lucide/svelte';
 	import type { HTMLAttributes } from 'svelte/elements';
 	import BlockLink from './BlockLink.svelte';
@@ -45,11 +53,36 @@
 	// they still appear as read-only full cards beneath their parent.
 	let linkableChildren = $derived(record.children.filter((child) => child.title));
 
+	const relationSymbols: Partial<Record<PredicateSlug, LucideIcon>> = {
+		references: AtSignIcon,
+		about: CrosshairIcon,
+		responds_to: ReplyIcon,
+		counters: SwordsIcon,
+		created_by: PenLineIcon,
+		same_as: EqualIcon
+	};
+	let relationRows = $derived.by(() => {
+		const rows = new Map<LucideIcon, { labels: string[]; items: RecordLink[] }>();
+		for (const group of [...record.references, ...record.extras]) {
+			const symbol = relationSymbols[group.predicate] ?? ArrowRightIcon;
+			const row = rows.get(symbol) ?? { labels: [], items: [] };
+			const seen = new Set(row.items.map((item) => item.id));
+			row.labels.push(group.label);
+			row.items.push(...group.records.filter((item) => !seen.has(item.id)));
+			rows.set(symbol, row);
+		}
+		return [...rows].map(([symbol, { labels, items }]) => ({
+			symbol,
+			label: labels.join(', '),
+			items
+		}));
+	});
+
 	let hasRelations = $derived(
 		linkableChildren.length > 0 ||
+			relationRows.length > 0 ||
 			record.connections.length > 0 ||
-			record.tags.length > 0 ||
-			record.extras.length > 0
+			record.tags.length > 0
 	);
 	let rcrUrl = $derived(PUBLIC_RCR_URL ? `${PUBLIC_RCR_URL}/records/${record.id}` : undefined);
 </script>
@@ -119,6 +152,9 @@
 				{#if linkableChildren.length > 0}
 					<RelationList items={linkableChildren} symbol={CornerDownRightIcon} label="Children" />
 				{/if}
+				{#each relationRows as row (row.label)}
+					<RelationList items={row.items} symbol={row.symbol} label={row.label} />
+				{/each}
 				{#if record.connections.length > 0}
 					<RelationList
 						items={record.connections}
@@ -126,9 +162,6 @@
 						label="Connections"
 					/>
 				{/if}
-				{#each record.extras as group (group.label)}
-					<RelationList items={group.records} symbol={ArrowRightIcon} label={group.label} />
-				{/each}
 				{#if record.tags.length > 0}
 					<TopicList topics={record.tags} />
 				{/if}

--- a/src/lib/server/records.ts
+++ b/src/lib/server/records.ts
@@ -32,7 +32,7 @@ const ASSOCIATED_LIMIT = 150;
 const SIMILAR_LIMIT = 10;
 const FEED_LIMIT = 30;
 
-/** Incoming links with these predicates define what a record collects: an entity's works, a concept's tagged records, the artifacts about a subject. */
+/** Incoming links with these predicates count toward an index entry: an entity's works, a concept's tagged records, the artifacts about a subject. */
 const describingPredicates: PredicateSlug[] = [
 	'created_by',
 	'tagged_with',
@@ -354,42 +354,32 @@ export async function getRecordPage(id: number): Promise<RecordPage | null> {
 		columns: cardColumns,
 		with: {
 			...cardWith,
-			incomingLinks: {
-				where: {
-					predicate: {
-						in: [...containmentPredicates, 'related_to', 'same_as', ...describingPredicates]
-					}
-				},
-				with: sourceWith
-			}
+			incomingLinks: { with: sourceWith }
 		}
 	});
 	if (!row) return null;
 
 	const record = toCard(row);
 
-	// Entity and concept pages render their describing incoming links (works by
-	// an entity, records tagged with a concept) as a full-card gallery; artifact
-	// pages keep them as labeled link rows on the card instead.
+	// Entity and concept pages render every record linked to them (works by an
+	// entity, records tagged with a concept, works in a format) as a full-card
+	// gallery; artifact pages keep them as labeled link rows on the card instead.
 	const collectsRecords = record.type !== 'artifact';
+	const isSymmetric = (predicate: string) =>
+		isPredicateSlug(predicate) && PREDICATES[predicate].inverseSlug === predicate;
 	const associatedIds = collectsRecords
 		? [
-				...new Set(
-					row.incomingLinks.flatMap((link) =>
-						isPredicateSlug(link.predicate) &&
-						describingPredicates.includes(link.predicate) &&
-						isListable(link.source)
-							? [link.source.id]
-							: []
+				...new Set([
+					...row.incomingLinks.flatMap((link) => (isListable(link.source) ? [link.source.id] : [])),
+					...row.outgoingLinks.flatMap((link) =>
+						isSymmetric(link.predicate) && isListable(link.target) ? [link.target.id] : []
 					)
-				)
+				])
 			]
 		: [];
-	const stripDescribing = (groups: LinkGroup[]): LinkGroup[] =>
-		groups.filter(
-			(group) => !(group.direction === 'incoming' && describingPredicates.includes(group.predicate))
-		);
-	const referenceLinks = collectsRecords ? stripDescribing(record.references) : record.references;
+	const stripIncoming = (groups: LinkGroup[]): LinkGroup[] =>
+		groups.filter((group) => group.direction !== 'incoming');
+	const referenceLinks = collectsRecords ? stripIncoming(record.references) : record.references;
 	const referenceIds = [
 		...new Set(referenceLinks.flatMap((group) => group.records.map((link) => link.id)))
 	];
@@ -427,7 +417,7 @@ export async function getRecordPage(id: number): Promise<RecordPage | null> {
 
 	return {
 		record: collectsRecords
-			? { ...record, references: referenceLinks, extras: stripDescribing(record.extras) }
+			? { ...record, references: referenceLinks, extras: stripIncoming(record.extras) }
 			: record,
 		references,
 		children,


### PR DESCRIPTION
The compact relations nav on a record card showed children, "related to" connections, the inverse-view extras, and tags, but never the reference bucket. Links such as references, about, responded by, and same as reached the page only as full-card sections rendered below the children, so a record that directly references two works showed nothing of that in its own card.

- Renders the reference and extra groups in the card's relations nav, merged into one inline list per symbol. Both directions of a predicate share a list, and the hover title carries every label the list holds.
- Gives each predicate family its own icon: at-sign for references, crosshair for about, reply for responded by, swords for counters, pen-line for creator of, equals for same as, and a right arrow for the rest.

The page query loads every incoming link instead of a fixed predicate list, so countered-by links reach the card. Entity and concept galleries collect every record linked to them (plus the targets of their own symmetric links), where before an entity known only through edited-by, translated-by, or via links showed no associated records. The index counts still use the describing predicates only.