### PR TITLE
Show native controls on record videos

### DIFF
--- a/src/components/RecordMedia.svelte
+++ b/src/components/RecordMedia.svelte
@@ -18,6 +18,7 @@
 			src={media.url}
 			aria-label={media.altText ?? undefined}
 			autoplay
+			controls
 			muted
 			loop
 			playsinline


### PR DESCRIPTION
Videos on a record card autoplay muted with no way to unmute short of right-clicking and choosing "Show all controls". Adds the native `controls` attribute, so the browser fades controls in on hover and out while the video plays untouched, and the mute button is a click away. The list-view thumbnails stay control-free: they sit inside the record link at thumbnail size.