### PR TITLE
List related entities and concepts under the page heading

### DIFF
--- a/src/components/RecordCard.svelte
+++ b/src/components/RecordCard.svelte
@@ -1,22 +1,13 @@
 <script lang="ts">
 	import { classnames } from '#helpers/classnames.js';
 	import markdown from '#helpers/markdown.js';
-	import { visualMedia, type RecordCard, type RecordLink } from '#lib/records.js';
+	import { relationRows, visualMedia, type RecordCard } from '#lib/records.js';
 	import { PUBLIC_RCR_URL } from '$app/env/public';
-	import type { PredicateSlug } from '@aias/hozo';
 	import {
 		ArrowLeftRightIcon,
-		ArrowRightIcon,
-		AtSignIcon,
 		CloudIcon,
 		CornerDownRightIcon,
-		CrosshairIcon,
-		EqualIcon,
-		ListCollapseIcon,
-		PenLineIcon,
-		ReplyIcon,
-		SwordsIcon,
-		type LucideIcon
+		ListCollapseIcon
 	} from '@lucide/svelte';
 	import type { HTMLAttributes } from 'svelte/elements';
 	import BlockLink from './BlockLink.svelte';
@@ -53,34 +44,11 @@
 	// they still appear as read-only full cards beneath their parent.
 	let linkableChildren = $derived(record.children.filter((child) => child.title));
 
-	const relationSymbols: Partial<Record<PredicateSlug, LucideIcon>> = {
-		references: AtSignIcon,
-		about: CrosshairIcon,
-		responds_to: ReplyIcon,
-		counters: SwordsIcon,
-		created_by: PenLineIcon,
-		same_as: EqualIcon
-	};
-	let relationRows = $derived.by(() => {
-		const rows = new Map<LucideIcon, { labels: string[]; items: RecordLink[] }>();
-		for (const group of [...record.references, ...record.extras]) {
-			const symbol = relationSymbols[group.predicate] ?? ArrowRightIcon;
-			const row = rows.get(symbol) ?? { labels: [], items: [] };
-			const seen = new Set(row.items.map((item) => item.id));
-			row.labels.push(group.label);
-			row.items.push(...group.records.filter((item) => !seen.has(item.id)));
-			rows.set(symbol, row);
-		}
-		return [...rows].map(([symbol, { labels, items }]) => ({
-			symbol,
-			label: labels.join(', '),
-			items
-		}));
-	});
+	let rows = $derived(relationRows([...record.references, ...record.extras]));
 
 	let hasRelations = $derived(
 		linkableChildren.length > 0 ||
-			relationRows.length > 0 ||
+			rows.length > 0 ||
 			record.connections.length > 0 ||
 			record.tags.length > 0
 	);
@@ -152,7 +120,7 @@
 				{#if linkableChildren.length > 0}
 					<RelationList items={linkableChildren} symbol={CornerDownRightIcon} label="Children" />
 				{/if}
-				{#each relationRows as row (row.label)}
+				{#each rows as row (row.label)}
 					<RelationList items={row.items} symbol={row.symbol} label={row.label} />
 				{/each}
 				{#if record.connections.length > 0}

--- a/src/lib/records.ts
+++ b/src/lib/records.ts
@@ -1,3 +1,4 @@
+import { capitalize } from '#helpers/grammar.js';
 import { resolve } from '$app/paths';
 import {
 	PREDICATES,
@@ -132,7 +133,7 @@ export const relationRows = (groups: LinkGroup[]): RelationRow[] => {
 	}
 	return [...rows].map(([symbol, { labels, items }]) => ({
 		symbol,
-		label: labels.join(', '),
+		label: labels.map(capitalize).join(', '),
 		items
 	}));
 };

--- a/src/lib/records.ts
+++ b/src/lib/records.ts
@@ -6,7 +6,22 @@ import {
 	type RecordSelect,
 	type RecordType
 } from '@aias/hozo';
-import { FileTextIcon, LightbulbIcon, UserIcon, type LucideIcon } from '@lucide/svelte';
+import {
+	ArrowLeftRightIcon,
+	ArrowRightIcon,
+	AtSignIcon,
+	CornerDownRightIcon,
+	CrosshairIcon,
+	EqualIcon,
+	FileTextIcon,
+	HashIcon,
+	LightbulbIcon,
+	PenLineIcon,
+	ReplyIcon,
+	SwordsIcon,
+	UserIcon,
+	type LucideIcon
+} from '@lucide/svelte';
 
 export type RecordFields = Omit<RecordSelect, 'textEmbedding' | 'textSearch'>;
 export type RecordLink = Pick<RecordSelect, 'id' | 'type' | 'title' | 'slug'>;
@@ -49,7 +64,14 @@ export interface RecordPage {
 	record: RecordCard;
 	references: ReferenceGroup[];
 	children: RecordCard[];
+	relations: LinkGroup[];
 	associated: RecordCard[];
+}
+
+export interface RelationRow {
+	symbol: LucideIcon;
+	label: string;
+	items: RecordLink[];
 }
 
 export interface IndexEntry extends RecordLink {
@@ -84,6 +106,35 @@ export const sectionIcons: Record<RecordType, LucideIcon> = {
 	artifact: FileTextIcon,
 	entity: UserIcon,
 	concept: LightbulbIcon
+};
+
+const relationSymbols: Partial<Record<PredicateSlug, LucideIcon>> = {
+	references: AtSignIcon,
+	about: CrosshairIcon,
+	responds_to: ReplyIcon,
+	counters: SwordsIcon,
+	created_by: PenLineIcon,
+	same_as: EqualIcon,
+	related_to: ArrowLeftRightIcon,
+	tagged_with: HashIcon,
+	contained_by: CornerDownRightIcon
+};
+
+export const relationRows = (groups: LinkGroup[]): RelationRow[] => {
+	const rows = new Map<LucideIcon, { labels: string[]; items: RecordLink[] }>();
+	for (const group of groups) {
+		const symbol = relationSymbols[group.predicate] ?? ArrowRightIcon;
+		const row = rows.get(symbol) ?? { labels: [], items: [] };
+		const seen = new Set(row.items.map((item) => item.id));
+		row.labels.push(group.label);
+		row.items.push(...group.records.filter((item) => !seen.has(item.id)));
+		rows.set(symbol, row);
+	}
+	return [...rows].map(([symbol, { labels, items }]) => ({
+		symbol,
+		label: labels.join(', '),
+		items
+	}));
 };
 
 export const sectionByPath = (path: string): Section | undefined =>

--- a/src/lib/server/records.ts
+++ b/src/lib/server/records.ts
@@ -212,6 +212,47 @@ const dedupeById = <T extends RecordLink>(items: T[]): T[] => {
 	});
 };
 
+type LinkRows = Pick<CardRow, 'outgoingLinks' | 'incomingLinks'>;
+
+function linkGroups(row: LinkRows, guard: typeof isListable = isListable): LinkGroup[] {
+	const groups = new Map<
+		string,
+		Pick<LinkGroup, 'predicate' | 'label' | 'direction'> & { rows: LinkRowRecord[] }
+	>();
+	const addGroup = (
+		predicate: PredicateSlug,
+		direction: LinkGroup['direction'],
+		rows: LinkRowRecord[]
+	) => {
+		if (rows.length === 0) return;
+		const label = direction === 'outgoing' ? outgoingLabel(predicate) : incomingLabel(predicate);
+		const group = groups.get(label) ?? { predicate, label, direction, rows: [] };
+		group.rows = [...group.rows, ...rows];
+		groups.set(label, group);
+	};
+	for (const predicate of predicateSlugs) {
+		if (!isPredicateSlug(predicate)) continue;
+		addGroup(
+			predicate,
+			'outgoing',
+			row.outgoingLinks.flatMap((link) =>
+				link.predicate === predicate && guard(link.target) ? [link.target] : []
+			)
+		);
+		addGroup(
+			predicate,
+			'incoming',
+			row.incomingLinks.flatMap((link) =>
+				link.predicate === predicate && guard(link.source) ? [link.source] : []
+			)
+		);
+	}
+	return [...groups.values()].map(({ rows, ...group }) => ({
+		...group,
+		records: dedupeById(rows.sort(byBestLink).map(pickLink))
+	}));
+}
+
 function toCard(row: CardRow): RecordCard {
 	const { media, outgoingLinks, incomingLinks, ...fields } = row;
 	// The nested link rows arrive unordered, and the chip rows they become
@@ -268,41 +309,9 @@ function toCard(row: CardRow): RecordCard {
 		)
 	].sort((a, b) => a.linkId - b.linkId);
 
-	// Self-inverse predicates share a label across directions, so grouping by
-	// label merges them into one deduplicated list, re-sorted once both
-	// directions are in.
-	const buckets: Record<
-		GroupBucket,
-		Map<string, Pick<LinkGroup, 'predicate' | 'label' | 'direction'> & { rows: LinkRowRecord[] }>
-	> = {
-		attributions: new Map(),
-		references: new Map(),
-		extras: new Map()
-	};
-	const addGroup = (
-		predicate: PredicateSlug,
-		direction: LinkGroup['direction'],
-		rows: LinkRowRecord[]
-	) => {
-		if (rows.length === 0) return;
-		const bucket = bucketFor(predicate, direction);
-		if (!bucket) return;
-		const label = direction === 'outgoing' ? outgoingLabel(predicate) : incomingLabel(predicate);
-		const group = buckets[bucket].get(label) ?? { predicate, label, direction, rows: [] };
-		group.rows = [...group.rows, ...rows];
-		buckets[bucket].set(label, group);
-	};
-	// Declaration order in PREDICATES keeps citation phrases and relation rows stable.
-	for (const predicate of predicateSlugs) {
-		if (!isPredicateSlug(predicate)) continue;
-		addGroup(predicate, 'outgoing', targets(predicate));
-		addGroup(predicate, 'incoming', sources(predicate));
-	}
+	const groups = linkGroups(row);
 	const groupsOf = (bucket: GroupBucket): LinkGroup[] =>
-		[...buckets[bucket].values()].map(({ rows, ...group }) => ({
-			...group,
-			records: dedupeById(rows.sort(byBestLink).map(pickLink))
-		}));
+		groups.filter((group) => bucketFor(group.predicate, group.direction) === bucket);
 
 	// Children double as read-only full-card content, so titleless records
 	// stay in the list; the card filters them out of its clickable chips.
@@ -361,36 +370,39 @@ export async function getRecordPage(id: number): Promise<RecordPage | null> {
 
 	const record = toCard(row);
 
-	// Entity and concept pages render every record linked to them (works by an
-	// entity, records tagged with a concept, works in a format) as a full-card
-	// gallery; artifact pages keep them as labeled link rows on the card instead.
-	const collectsRecords = record.type !== 'artifact';
-	const isSymmetric = (predicate: string) =>
-		isPredicateSlug(predicate) && PREDICATES[predicate].inverseSlug === predicate;
-	const associatedIds = collectsRecords
-		? [
-				...new Set([
-					...row.incomingLinks.flatMap((link) => (isListable(link.source) ? [link.source.id] : [])),
-					...row.outgoingLinks.flatMap((link) =>
-						isSymmetric(link.predicate) && isListable(link.target) ? [link.target.id] : []
-					)
-				])
-			]
-		: [];
-	const stripIncoming = (groups: LinkGroup[]): LinkGroup[] =>
-		groups.filter((group) => group.direction !== 'incoming');
-	const referenceLinks = collectsRecords ? stripIncoming(record.references) : record.references;
-	const referenceIds = [
-		...new Set(referenceLinks.flatMap((group) => group.records.map((link) => link.id)))
-	];
+	if (record.type !== 'artifact') {
+		const isArtifact = <T extends LinkRowRecord>(linked: T | null): linked is T =>
+			isListable(linked) && linked.type === 'artifact';
+		const isPeer = <T extends LinkRowRecord>(linked: T | null): linked is T =>
+			isListable(linked) && linked.type !== 'artifact';
+		const isSymmetric = (predicate: string) =>
+			isPredicateSlug(predicate) && PREDICATES[predicate].inverseSlug === predicate;
+		const associatedIds = [
+			...new Set([
+				...row.incomingLinks.flatMap((link) => (isArtifact(link.source) ? [link.source.id] : [])),
+				...row.outgoingLinks.flatMap((link) =>
+					isSymmetric(link.predicate) && isArtifact(link.target) ? [link.target.id] : []
+				)
+			])
+		];
+		return {
+			record,
+			references: [],
+			children: [],
+			relations: linkGroups(row, isPeer),
+			associated: await getRecordCards(associatedIds, 'best', ASSOCIATED_LIMIT)
+		};
+	}
 
-	const [children, connectionCards, associated, referenceCards] = await Promise.all([
+	const referenceIds = [
+		...new Set(record.references.flatMap((group) => group.records.map((link) => link.id)))
+	];
+	const [children, connectionCards, referenceCards] = await Promise.all([
 		getRecordCards(
 			record.children.map((child) => child.id),
 			'chronological'
 		),
 		getRecordCards(record.connections.map((connection) => connection.id)),
-		getRecordCards(associatedIds, 'best', ASSOCIATED_LIMIT),
 		getRecordCards(referenceIds)
 	]);
 
@@ -405,7 +417,7 @@ export async function getRecordPage(id: number): Promise<RecordPage | null> {
 	// the fetched cards, keeping the best-first order of the card query.
 	// Explicit connections join them as their own labeled group.
 	const references = [
-		...referenceLinks.flatMap((group) => {
+		...record.references.flatMap((group) => {
 			const ids = new Set(group.records.map((link) => link.id));
 			const cards = referenceCards.filter((card) => ids.has(card.id));
 			return cards.length > 0 ? [{ label: group.label, records: cards }] : [];
@@ -415,14 +427,7 @@ export async function getRecordPage(id: number): Promise<RecordPage | null> {
 			: [])
 	];
 
-	return {
-		record: collectsRecords
-			? { ...record, references: referenceLinks, extras: stripIncoming(record.extras) }
-			: record,
-		references,
-		children,
-		associated
-	};
+	return { record, references, children, relations: [], associated: [] };
 }
 
 export async function getSimilarRecords(id: number): Promise<RecordCard[]> {

--- a/src/routes/app/RecordItem.svelte
+++ b/src/routes/app/RecordItem.svelte
@@ -83,6 +83,7 @@
 		display: flex;
 		flex-direction: column;
 		gap: 0.5em;
+		padding-block: 0.25em;
 		font-size: var(--font-size-small);
 	}
 

--- a/src/routes/app/RecordItem.svelte
+++ b/src/routes/app/RecordItem.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
 	import RecordCard from '#components/RecordCard.svelte';
 	import RecordGallery from '#components/RecordGallery.svelte';
-	import { displayTitle, type RecordPage } from '#lib/records.js';
+	import RelationList from '#components/RelationList.svelte';
+	import { displayTitle, relationRows, type RecordPage } from '#lib/records.js';
 	import { similarRecords } from '#lib/records.remote.js';
 	import { ArrowLeftRightIcon } from '@lucide/svelte';
 	import RecordList from './RecordList.svelte';
@@ -11,7 +12,8 @@
 	}
 	let { page }: RecordItemProps = $props();
 
-	let { record, references, children, associated } = $derived(page);
+	let { record, references, children, relations, associated } = $derived(page);
+	let rows = $derived(relationRows(relations));
 	// Semantic neighbors load after the record itself, so navigation never
 	// waits on the similarity query.
 	let similarQuery = $derived(record.type === 'artifact' ? similarRecords(record.id) : undefined);
@@ -49,10 +51,19 @@
 		{/if}
 	</article>
 {:else}
-	<h1>
-		{displayTitle(record)}
-		{#if record.abbreviation}<small class="text-secondary">({record.abbreviation})</small>{/if}
-	</h1>
+	<header>
+		<h1>
+			{displayTitle(record)}
+			{#if record.abbreviation}<small class="text-secondary">({record.abbreviation})</small>{/if}
+		</h1>
+		{#if rows.length > 0}
+			<nav class="relations">
+				{#each rows as row (row.label)}
+					<RelationList items={row.items} symbol={row.symbol} label={row.label} />
+				{/each}
+			</nav>
+		{/if}
+	</header>
 	{#if associated.length > 0}
 		<RecordGallery records={associated} />
 	{:else}
@@ -61,8 +72,18 @@
 {/if}
 
 <style>
-	h1 {
-		margin-block-end: 0.5em;
+	header {
+		display: flex;
+		flex-direction: column;
+		gap: 0.5em;
+		margin-block-end: 1em;
+	}
+
+	.relations {
+		display: flex;
+		flex-direction: column;
+		gap: 0.5em;
+		font-size: var(--font-size-small);
 	}
 
 	article {


### PR DESCRIPTION
Entity and concept pages collect every record linked to them into the card gallery, so a concept like [Gold](https://barnsworthburning.net/records/46466/gold) shows its related concepts (Color, Metal, Yellow) as full cards beside the artifacts that mention it. Those peer records have no content worth a card, and they crowd out the artifacts the page exists to collect.

- The gallery holds only artifacts. Fellow entities and concepts render as icon-led, slash-separated relation rows between the heading and the gallery, using the same row component and predicate icons as the record card.
- The card's predicate-to-icon map and row merging move into the shared records module so the page and the card build rows the same way. Rows gain icons for connections, tags, and containment.
- Entity and concept pages stop fetching the reference, child, and connection cards they never rendered.

Both directions of a predicate merge under one icon, matching the card, so an organization and its members share the containment row and a concept's broader and narrower concepts share the tag row.

Also: relation row hover titles capitalize each predicate label ("References, Referenced by") on the page, the card, and the trail.