### PR TITLE
Jump to search with cmd+K

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -96,19 +96,33 @@
 		goto(trailHref(page.url, []), { shallow: true, state: { trail: [] } });
 	};
 
+	const focusSearch = () => {
+		if (page.route.id === '/search') {
+			document.getElementById('search-query')?.focus();
+		} else {
+			void goto('/search');
+		}
+	};
+
 	const handleInteractions = (event: KeyboardEvent | MouseEvent) => {
 		interaction.setAltKeyPressed(event.altKey);
 		interaction.setMetaKeyPressed(event.metaKey);
-		if (event instanceof KeyboardEvent) {
-			if (event.key === 'Escape') {
-				clearTrail();
-			}
+	};
+
+	const handleKeydown = (event: KeyboardEvent) => {
+		handleInteractions(event);
+		if (event.key === 'Escape') {
+			clearTrail();
+		}
+		if (event.key === 'k' && (event.metaKey || event.ctrlKey)) {
+			event.preventDefault();
+			focusSearch();
 		}
 	};
 </script>
 
 <svelte:window
-	on:keydown={handleInteractions}
+	on:keydown={handleKeydown}
 	on:keyup={handleInteractions}
 	on:mouseenter={handleInteractions}
 	on:mouseleave={handleInteractions}

--- a/src/routes/search/+page.svelte
+++ b/src/routes/search/+page.svelte
@@ -43,6 +43,7 @@
 	<form data-sveltekit-reset="false" class="search-input">
 		<TextInput
 			type="search"
+			id="search-query"
 			name="q"
 			placeholder="Search records..."
 			value={searchValue}


### PR DESCRIPTION
Reaching the search field means clicking the Search link in the nav and then the input. Cmd+K (Ctrl+K on Windows and Linux) now does both from any page: it navigates to the search page, where SvelteKit's post-navigation focus reset lands on the autofocused input. On the search page itself it focuses the input directly, so the current query and results stay put.

The shortcut lives in a keydown-only handler in the root layout. The previous handler ran on keyup as well, which would have fired the shortcut twice per press, so Escape moves into the same keydown handler and stops clearing the trail twice.