### PR TITLE
Mute trail links to records already open in the trail

### DIFF
--- a/src/components/Link.svelte
+++ b/src/components/Link.svelte
@@ -33,8 +33,14 @@
 	}: LinkProps = $props();
 
 	let getTrailSegment: (() => TrailSegment) | undefined = getContext('trailSegment');
+	let getOpenRecordIds: (() => number[]) | undefined = getContext('openRecordIds');
 
 	let url = $derived(href ?? (record ? recordPath(record) : '#'));
+	let muted = $derived(
+		record !== undefined &&
+			record.id !== getTrailSegment?.().entityId &&
+			(getOpenRecordIds?.().includes(record.id) ?? false)
+	);
 
 	const handleClick = () => {
 		trail.selectSegment(getTrailSegment?.().entityId);
@@ -42,6 +48,6 @@
 	};
 </script>
 
-<a onclick={handleClick} href={url} class:inherit class:active {...restProps}
+<a onclick={handleClick} href={url} class:inherit class:active class:muted {...restProps}
 	>{@render children()}</a
 >

--- a/src/routes/app/Trail.svelte
+++ b/src/routes/app/Trail.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { classnames } from '#helpers/classnames.js';
 	import type { TrailSegment as TrailSegmentData } from '#lib/trail.svelte.js';
+	import { setContext } from 'svelte';
 	import type { HTMLOlAttributes } from 'svelte/elements';
 	import TrailSegment from './TrailSegment.svelte';
 
@@ -8,6 +9,8 @@
 		segments: TrailSegmentData[];
 	}
 	let { segments, ...restProps }: TrailProps = $props();
+
+	setContext('openRecordIds', () => segments.map((segment) => segment.entityId));
 </script>
 
 <ol class:trail={true} {...restProps}>

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -133,6 +133,11 @@
 	}
 }
 
+.muted:not(.block-link .main-link),
+.block-link:has(.main-link.muted) {
+	opacity: 0.5;
+}
+
 .extract {
 	--layout-gap: 0.5em;
 	border: 1px solid var(--divider);


### PR DESCRIPTION
Panels in the trail are full of links to other records, and with several panels open it is easy to click into one that is already showing a few columns over. Nothing on the link hinted that the record was already open.

Links inside a trail segment now render at half opacity when they point at a record that already has a panel, so an open record reads as visited at a glance. A segment's own record stays at full strength on its headline card. When the muted link is the main link of a list row or gallery card, the whole entry dims rather than just its title, so a row never shows a faded title above a bright summary and thumbnail.

The trail publishes its open record ids through context, so the index and main pane are unaffected.