### PR TITLE
Clarify relationship and summary markers

### DIFF
--- a/src/components/RecordCard.svelte
+++ b/src/components/RecordCard.svelte
@@ -7,7 +7,7 @@
 		ArrowLeftRightIcon,
 		CloudIcon,
 		CornerDownRightIcon,
-		ListCollapseIcon
+		TextAlignStartIcon
 	} from '@lucide/svelte';
 	import type { HTMLAttributes } from 'svelte/elements';
 	import BlockLink from './BlockLink.svelte';
@@ -102,7 +102,7 @@
 			{/if}
 			{#if record.summary}
 				<div class="extract-summary" title="Summary">
-					<ListCollapseIcon class="summary-symbol" />
+					<TextAlignStartIcon class="summary-symbol" />
 					<div class="content">
 						{@html markdown.parse(record.summary)}
 					</div>

--- a/src/components/RelationList.svelte
+++ b/src/components/RelationList.svelte
@@ -1,12 +1,8 @@
 <script lang="ts">
-	import { displayTitle, type RecordLink } from '#lib/records.js';
-	import type { LucideIcon } from '@lucide/svelte';
+	import { displayTitle, type RelationRow } from '#lib/records.js';
 	import Link from './Link.svelte';
 
-	interface RelationListProps {
-		items: RecordLink[];
-		label: string;
-		symbol: LucideIcon;
+	interface RelationListProps extends RelationRow {
 		maxChildren?: number;
 	}
 
@@ -27,9 +23,13 @@
 </script>
 
 {#if items?.length > 0}
-	{@const Symbol = symbol}
 	<div class="relation-list" title={label}>
-		<Symbol class="relation-symbol" />
+		{#if typeof symbol === 'string'}
+			<span class="relation-label">{symbol}</span>
+		{:else}
+			{@const Symbol = symbol}
+			<Symbol class="relation-symbol" />
+		{/if}
 		<ol>
 			{#each displayedItems as item (item.id)}
 				<li><Link record={item}>{displayTitle(item)}</Link></li>
@@ -55,6 +55,11 @@
 
 		& :global(.relation-symbol) {
 			margin-block-start: calc((1lh - 1em) / 2);
+			color: var(--hint);
+		}
+
+		.relation-label {
+			flex-shrink: 0;
 			color: var(--hint);
 		}
 

--- a/src/lib/records.ts
+++ b/src/lib/records.ts
@@ -11,15 +11,14 @@ import {
 	ArrowLeftRightIcon,
 	ArrowRightIcon,
 	AtSignIcon,
+	CircleDotIcon,
 	CornerDownRightIcon,
-	CrosshairIcon,
 	EqualIcon,
 	FileTextIcon,
 	HashIcon,
 	LightbulbIcon,
 	PenLineIcon,
 	ReplyIcon,
-	SwordsIcon,
 	UserIcon,
 	type LucideIcon
 } from '@lucide/svelte';
@@ -70,7 +69,7 @@ export interface RecordPage {
 }
 
 export interface RelationRow {
-	symbol: LucideIcon;
+	symbol: LucideIcon | string;
 	label: string;
 	items: RecordLink[];
 }
@@ -111,9 +110,8 @@ export const sectionIcons: Record<RecordType, LucideIcon> = {
 
 const relationSymbols: Partial<Record<PredicateSlug, LucideIcon>> = {
 	references: AtSignIcon,
-	about: CrosshairIcon,
+	about: CircleDotIcon,
 	responds_to: ReplyIcon,
-	counters: SwordsIcon,
 	created_by: PenLineIcon,
 	same_as: EqualIcon,
 	related_to: ArrowLeftRightIcon,
@@ -122,9 +120,12 @@ const relationSymbols: Partial<Record<PredicateSlug, LucideIcon>> = {
 };
 
 export const relationRows = (groups: LinkGroup[]): RelationRow[] => {
-	const rows = new Map<LucideIcon, { labels: string[]; items: RecordLink[] }>();
+	const rows = new Map<RelationRow['symbol'], { labels: string[]; items: RecordLink[] }>();
 	for (const group of groups) {
-		const symbol = relationSymbols[group.predicate] ?? ArrowRightIcon;
+		const symbol =
+			group.predicate === 'counters'
+				? capitalize(group.label)
+				: (relationSymbols[group.predicate] ?? ArrowRightIcon);
 		const row = rows.get(symbol) ?? { labels: [], items: [] };
 		const seen = new Set(row.items.map((item) => item.id));
 		row.labels.push(group.label);


### PR DESCRIPTION
The swords and crosshair imagery distract from record relationships, while the summary icon suggests a collapse control. Replaces them with directional "Counters" / "Countered by" labels, a circle-dot for "About", and plain text lines for summaries.
